### PR TITLE
fix for long variant names

### DIFF
--- a/src/components/CombineChangeVariantPopup.vue
+++ b/src/components/CombineChangeVariantPopup.vue
@@ -28,7 +28,7 @@
             <label
               class="change-variant-popup__result-item"
               :for="`variant-${variant.layer}`">
-              <span v-test="'variantName'">{{ variant.metadata.title }}</span>
+              <span v-test="'variantName'">{{ getWrappingTitle(variant) }}</span>
 
               <dl class="change-variant-popup__result-item-props">
                 <div :key="name" v-for="{name, value} in getPropsForVariant(variant)">
@@ -144,7 +144,12 @@ export default {
             value: variant.properties[prop]
           }
         })
-    }
+    },
+
+    getWrappingTitle(variant) {
+      /* Add a zero width space after underscore to force a break */
+      return variant.metadata.title.replace(/_/g, '_&#8203;')
+    },
   },
   computed: {
     ...mapState(['variantFilterProperties']),


### PR DESCRIPTION
Wrap long variant names (containing underscores) by inserting a zero width space