### PR TITLE
fix deselect last marker

### DIFF
--- a/src/views/Combine.vue
+++ b/src/views/Combine.vue
@@ -596,6 +596,10 @@ export default {
           return selectedIds.includes(layerSet.feature.id)
         })
         this.scenarioLayerSets = scenarioLayerSets
+
+        if(!this.scenarioLayerSets.length) {
+          this.layerSetCollapsed = false
+        }
       } else if(this.selectFeatureMode === 'multiple') { // we just selected this feature, add it to the list
         this.selectedFeatures.push(feature)
       } else {


### PR DESCRIPTION
Fix wrong legend being shown when deselecting the last marker by reopening the "Algemeen" panel. 