### PR TITLE
Liwo 972 close and html notification fixes

### DIFF
--- a/src/components/NotificationBar.vue
+++ b/src/components/NotificationBar.vue
@@ -5,7 +5,6 @@
       v-if="notification.show"
       :key="index"
       class="viewer__notification"
-      @click="notification.show = false"
     >
       <aside
         class="notification-bar"
@@ -17,7 +16,9 @@
           <p class="notification-bar__message" v-html="notification.message" />
           <button
             class="pop-up__close panel-close"
-            v-test="'notification-button'">
+            v-test="'notification-button'"
+            @click="notification.show = false"
+          >
             <span class="icon-close-big" aria-hidden="true"></span>
             <span class="sr-only">Sluiten</span>
           </button>

--- a/src/components/NotificationBar.vue
+++ b/src/components/NotificationBar.vue
@@ -14,7 +14,7 @@
       >
         <div class="container">
           <img class="notification-bar__icon" :src="`${publicPath}icons/baseline-${notification.type}-24px.svg`" alt="" />
-          <p class="notification-bar__message">{{ notification.message }}</p>
+          <p class="notification-bar__message" v-html="notification.message" />
           <button
             class="pop-up__close panel-close"
             v-test="'notification-button'">

--- a/src/components/NotificationBar.vue
+++ b/src/components/NotificationBar.vue
@@ -13,7 +13,9 @@
       >
         <div class="container">
           <img class="notification-bar__icon" :src="`${publicPath}icons/baseline-${notification.type}-24px.svg`" alt="" />
-          <p class="notification-bar__message" v-html="notification.message" />
+          <p class="notification-bar__message">
+            {{ notification.message }}
+          </p>
           <button
             class="pop-up__close panel-close"
             v-test="'notification-button'"

--- a/tests/e2e/specs/ui/scenarios/notifications.js
+++ b/tests/e2e/specs/ui/scenarios/notifications.js
@@ -27,18 +27,8 @@ describe('Notifications', () => {
       .should('exist')
   })
 
-  it('Can be closed by clicking on them', () => {
-
-    cy.get(selector('notification-button'))
-      .should('exist')
-      .click()
-
-    cy.get(selector('notification-button'))
-      .should('not.exist')
-  })
-
   it('Can be closed using the close button', () => {
-    cy.get(selector('notification'))
+    cy.get(selector('notification-button'))
       .should('exist')
       .click()
 


### PR DESCRIPTION
Go to `/#/viewer/11` and see how the notification only closes if you click on the cross. So now an user can for example copy the link in the notification