### PR TITLE
Liwo 955 966 close export and make fields required

### DIFF
--- a/src/components/ExportCombinedPopUp.vue
+++ b/src/components/ExportCombinedPopUp.vue
@@ -1,32 +1,32 @@
 <template>
-  <pop-up class="export-popup" title="Exporteer" @close="$emit('close')">
-    <form class="export-popup__content export-popup__form-columns">
-      <div class="export-popup__notification export-popup__notification--loading" v-if="!eeLayer">
-        <b>Wacht tot de data geladen is.</b>
+  <pop-up class="export-combined-popup" title="Exporteer als zip" @close="$emit('close')">
+    <form class="export-combined-popup__content export-combined-popup__form-columns">
       </div>
-      <div class="export-popup__notification export-popup__notification--loading" v-if="exporting">
-        <b>Uw export wordt gegenereerd.</b>
+      <div
+        class="export-combined-popup__notification export-combined-popup__notification--loading"
+        role="status"
+        aria-live="polite"
+      >
+        <template v-if="exporting || !eeLayer">
+          <p v-if="exporting" class="export-combined-popup__notification-text">Uw export wordt gegenereerd.</p>
+          <p v-if="!eeLayer" class="export-combined-popup__notification-text">Data wordt geladen.</p>
+          <div class="lds-dual-ring export-combined-popup__notification-loader" />
+        </template>
       </div>
-      <label class="export-popup__form-column-item" for="export-zip">Exporteer als:</label>
-      <ul class="export-popup__form-column-item choice-cards export-popup__radio-group">
-        <li class="choice-cards__item">
-          <input type="radio" name="export" v-model="exportType"
-            id="export-zip" value="zip"
-            class="sr-only choice-cards__item__radio export-popup__export-input"
-          >
-          <label class="radio choice-cards__item__label export-popup__export-label" for="export-zip">
-            <span aria-hidden="true" class="icon icon-file-zip icon-2x"></span>
-            <span>Zip</span>
-          </label>
-        </li>
-      </ul>
-      <label class="export-popup__form-column-item" for="export-name">
-        Schaal:<br><small class="help">Schaal in meters</small>
+      <label class="export-combined-popup__form-column-item" for="export-name">
+        <span>Schaal:</span>
+        <span class="help">Schaal in meters</span>
       </label>
-      <input type="number" name="scale"
-        id="export-scale" autocomplete="off" v-model="exportScale"
-        class="export-popup__form-column-item export-popup__textfield">
-      <footer v-if="eeLayer" class="export-popup__footer">
+      <input
+        class="export-combined-popup__form-column-item export-combined-popup__textfield"
+        type="number"
+        name="scale"
+        id="export-scale"
+        autocomplete="off"
+        v-model="exportScale"
+        required
+      />
+      <footer v-if="eeLayer" class="export-combined-popup__footer">
         <button
           class="btn primary"
           @click.prevent="exportMap"
@@ -147,63 +147,77 @@ export default {
 </script>
 
 <style>
-  .export-popup__content {
+  .export-combined-popup__content {
     padding: 1.5rem;
   }
-
-  .export-popup__form-columns {
+  .export-combined-popup__form-columns {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     margin-bottom: 0;
   }
-  .export-popup__form-columns > * {
+  .export-combined-popup__form-columns > * {
     width: 100%;
     margin: 0 0 1rem 0;
     padding: 0;
   }
-  .export-popup__form-column-item {
-    display: block;
+  .export-combined-popup__form-column-item {
+    display: flex;
+    flex-direction: column;
     width: calc(50% - 1rem);
   }
-  .export-popup .choice-cards {
+  .export-combined-popup .choice-cards {
     display: flex;
     justify-content: space-between;
     text-align: left;
   }
-  .export-popup .choice-cards__item {
+  .export-combined-popup .choice-cards__item {
     width: 100%;
     flex: 0 1 100%;
     margin-bottom: 10px;
   }
-  .export-popup .choice-cards__item__label {
+  .export-combined-popup .choice-cards__item__label {
     text-align: left;
     margin: 0;
     padding: 8px 16px;
   }
-  .export-popup .choice-cards__item__radio:checked+.choice-cards__item__label:after {
+  .export-combined-popup .choice-cards__item__radio:checked+.choice-cards__item__label:after {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
     border-radius: 3px;
   }
-  .export-popup .btn:focus {
+  .export-combined-popup .btn:focus {
     text-decoration: none;
   }
-  .export-popup__footer button {
+  .export-combined-popup__footer button {
     margin-right: 10px;
   }
-  .export-popup__notification {
+  .export-combined-popup__notification {
     color: #ffffff;
     background: gray;
     padding: 10px;
     border-radius: 3px;
+    font-weight: bold;
   }
-  .export-popup__notification--error {
+  .export-combined-popup__notification:empty {
+    display: none;
+  }
+  .export-combined-popup__notification--error {
     background:red;
   }
-  .export-popup__notification--loading {
+  .export-combined-popup__notification--loading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
     background: #0b71ab;
+  }
+  .export-combined-popup__notification-text {
+    margin: 0;
+  }
+  .export-combined-popup__notification .export-combined-popup__notification-loader:after {
+    height: 1.5rem;
+    width: 1.5rem;
   }
 </style>

--- a/src/components/ExportCombinedPopUp.vue
+++ b/src/components/ExportCombinedPopUp.vue
@@ -20,7 +20,7 @@
           <div class="lds-dual-ring export-combined-popup__notification-loader" />
         </template>
       </div>
-      <label class="export-combined-popup__form-column-item" for="export-name">
+      <label class="export-combined-popup__form-column-item" for="export-scale">
         <span>Schaal:</span>
         <span class="help">Schaal in meters</span>
       </label>
@@ -87,11 +87,7 @@ export default {
   },
   methods: {
     validateForm () {
-      if (!this.exportScale) {
-        this.hasError = true
-      } else if (this.exportScale) {
-        this.hasError = false
-      }
+      this.hasError = !this.exportScale
     },
     async exportMap () {
       if (!this.hasError && !this.exporting) {

--- a/src/components/ExportCombinedPopUp.vue
+++ b/src/components/ExportCombinedPopUp.vue
@@ -1,17 +1,14 @@
 <template>
   <pop-up class="export-combined-popup" title="Exporteer als zip" @close="$emit('close')">
-    <form class="export-combined-popup__content export-combined-popup__form-columns">
+    <form class="export-combined-popup__content export-combined-popup__form-columns" @submit.prevent="exportMap">
       <div
         class="export-combined-popup__notification export-combined-popup__notification--error"
         role="alert"
         aria-live="assertive"
       >
-        <ul v-if="formErrors.length">
-          <li v-for="(error, index) in formErrors" :key="index">
-            {{ error }}
-          </li>
-        </ul>
+        <p v-if="hasError" class="export-popup__notification-text">Schaal is verplicht</p>
       </div>
+
       <div
         class="export-combined-popup__notification export-combined-popup__notification--loading"
         role="status"
@@ -39,7 +36,7 @@
       <footer v-if="eeLayer" class="export-combined-popup__footer">
         <button
           class="btn primary"
-          @click.prevent="exportMap"
+          @click="validateForm"
           v-test="'export-combined-button'"
         >
           Exporteer
@@ -68,7 +65,7 @@ export default {
   },
   data () {
     return {
-      formErrors: [],
+      hasError: false,
       exportScale: 50,
       exporting: false
     }
@@ -89,14 +86,15 @@ export default {
     }
   },
   methods: {
-    async exportMap () {
-      if (!this.exportName && !this.formErrors.includes("Schaal is verplicht")) {
-        this.formErrors.push("Schaal is verplicht")
-      } else if (this.exportName) {
-        this.formErrors = []
+    validateForm () {
+      if (!this.exportScale) {
+        this.hasError = true
+      } else if (this.exportScale) {
+        this.hasError = false
       }
-
-      if (this.formErrors.length === 0 && !this.exporting) {
+    },
+    async exportMap () {
+      if (!this.hasError && !this.exporting) {
         this.exporting = true
         const eeLayer = this.eeLayer
         const body = {
@@ -223,7 +221,7 @@ export default {
     display: none;
   }
   .export-combined-popup__notification--error {
-    background:red;
+    background: red;
   }
   .export-combined-popup__notification--loading {
     display: flex;

--- a/src/components/ExportPopup.vue
+++ b/src/components/ExportPopup.vue
@@ -1,17 +1,14 @@
 <template>
   <pop-up class="export-popup" title="Exporteer als zip" @close="$emit('close')">
-    <form class="export-popup__content export-popup__form-columns">
+    <form class="export-popup__content export-popup__form-columns" @submit.prevent="exportMap">
       <div
         class="export-popup__notification export-popup__notification--error"
         role="alert"
         aria-live="assertive"
       >
-        <ul v-if="formErrors.length">
-          <li v-for="(error, index) in formErrors" :key="index">
-            {{ error }}
-          </li>
-        </ul>
+        <p v-if="hasError" class="export-popup__notification-text">Export naam is verplicht</p>
       </div>
+
       <div
         class="export-popup__notification export-popup__notification--loading"
         role="status"
@@ -22,6 +19,7 @@
           <div class="lds-dual-ring export-popup__notification-loader" />
         </template>
       </div>
+
       <label class="export-popup__form-column-item" for="export-name">
         <span>Naam:</span>
         <span class="help">De naam van het uitvoerbestand</span>
@@ -37,7 +35,7 @@
         required
       />
       <footer class="export-popup__footer">
-        <button class="btn primary" @click.prevent="exportMap" v-test="'export-file-button'">Exporteer</button>
+        <button class="btn primary" type="submit" @click="validateForm" v-test="'export-file-button'">Exporteer</button>
         <button class="btn secondary" type="reset" @click="$emit('close')">Annuleer</button>
       </footer>
     </form>
@@ -56,21 +54,22 @@ export default {
   },
   data () {
     return {
-      formErrors: [],
+      hasError:false,
       exporting: false, // starts false and after form validates becomes true
       exportName: ''
     }
   },
   components: { PopUp },
   methods: {
-    exportMap: function () {
-      if (!this.exportName && !this.formErrors.includes("Export naam is verplicht")) {
-        this.formErrors.push("Export naam is verplicht")
+    validateForm () {
+      if (!this.exportName ) {
+        this.hasError = true
       } else if (this.exportName) {
-        this.formErrors = []
+        this.hasError = false
       }
-
-      if (this.formErrors.length === 0 && !this.exporting) {
+    },
+    exportMap () {
+      if (!this.hasError && !this.exporting) {
         this.exporting = true
         const layers = this.mapLayers.map(
           layer => {
@@ -150,7 +149,7 @@ export default {
     display: none;
   }
   .export-popup__notification--error {
-    background:red;
+    background: red;
   }
   .export-popup__notification--loading {
     display: flex;

--- a/src/components/ExportPopup.vue
+++ b/src/components/ExportPopup.vue
@@ -1,21 +1,41 @@
 <template>
   <pop-up class="export-popup" title="Exporteer als zip" @close="$emit('close')">
     <form class="export-popup__content export-popup__form-columns">
-      <div class="export-popup__notification export-popup__notification--error" v-if="formErrors.length">
-        <b>Graag de volgende velden aanvullen:</b>
-        <ul>
-          <li v-for="(error, index) in formErrors" :key="index">{{ error }}</li>
+      <div
+        class="export-popup__notification export-popup__notification--error"
+        role="alert"
+        aria-live="assertive"
+      >
+        <ul v-if="formErrors.length">
+          <li v-for="(error, index) in formErrors" :key="index">
+            {{ error }}
+          </li>
         </ul>
       </div>
-      <div class="export-popup__notification export-popup__notification--loading" v-if="exporting">
-        <b>Uw export wordt gegenereerd.</b><div class="lds-dual-ring export-popup__notification-loader"></div>
+      <div
+        class="export-popup__notification export-popup__notification--loading"
+        role="status"
+        aria-live="polite"
+      >
+        <template v-if="exporting">
+          <p class="export-popup__notification-text">Uw export wordt gegenereerd.</p>
+          <div class="lds-dual-ring export-popup__notification-loader" />
+        </template>
       </div>
       <label class="export-popup__form-column-item" for="export-name">
-        Naam:<br><small class="help">De naam van het uitvoerbestand</small>
+        <span>Naam:</span>
+        <span class="help">De naam van het uitvoerbestand</span>
       </label>
-      <input type="text" name="name"
-        id="export-name" autocomplete="off" v-model="exportName"
-        class="export-popup__form-column-item export-popup__textfield" v-test="'name-input'">
+      <input
+        id="export-name"
+        class="export-popup__form-column-item export-popup__textfield"
+        name="name"
+        autocomplete="off"
+        v-model="exportName"
+        type="text"
+        v-test="'name-input'"
+        required
+      />
       <footer class="export-popup__footer">
         <button class="btn primary" @click.prevent="exportMap" v-test="'export-file-button'">Exporteer</button>
         <button class="btn secondary" type="reset" @click="$emit('close')">Annuleer</button>
@@ -44,20 +64,26 @@ export default {
   components: { PopUp },
   methods: {
     exportMap: function () {
-      if (!this.exportName) this.formErrors.push('Export naam is verplicht')
-      if (this.formErrors && this.formErrors.length === 0) { this.exporting = true }
+      if (!this.exportName && !this.formErrors.includes("Export naam is verplicht")) {
+        this.formErrors.push("Export naam is verplicht")
+      } else if (this.exportName) {
+        this.formErrors = []
+      }
 
-      const layers = this.mapLayers.map(
-        layer => {
-          // TODO: make this consistent
-          // this is actually the id of the variant
-          return layer.layer
-        }).join()
+      if (this.formErrors.length === 0 && !this.exporting) {
+        this.exporting = true
+        const layers = this.mapLayers.map(
+          layer => {
+            // TODO: make this consistent
+            // this is actually the id of the variant
+            return layer.layer
+          }).join()
 
       exportZip({ name: this.exportName, layers })
         .finally(() => {
           this.exporting = false
         })
+      }
     }
   }
 }
@@ -80,7 +106,8 @@ export default {
     padding: 0;
   }
   .export-popup__form-column-item {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: calc(50% - 1rem);
   }
   .export-popup .choice-cards {
@@ -116,6 +143,10 @@ export default {
     background: gray;
     padding: 10px;
     border-radius: 3px;
+    font-weight: bold;
+  }
+  .export-popup__notification:empty {
+    display: none;
   }
   .export-popup__notification--error {
     background:red;
@@ -125,6 +156,9 @@ export default {
     align-items: center;
     gap: 10px;
     background: #0b71ab;
+  }
+  .export-popup__notification-text {
+    margin: 0;
   }
   .export-popup__notification .export-popup__notification-loader:after {
     height: 1.5rem;

--- a/src/components/ExportPopup.vue
+++ b/src/components/ExportPopup.vue
@@ -79,10 +79,11 @@ export default {
             return layer.layer
           }).join()
 
-      exportZip({ name: this.exportName, layers })
-        .finally(() => {
-          this.exporting = false
-        })
+        exportZip({ name: this.exportName, layers })
+          .finally(() => {
+            this.exporting = false
+            this.$emit('close')
+          })
       }
     }
   }

--- a/src/components/ExportPopup.vue
+++ b/src/components/ExportPopup.vue
@@ -62,11 +62,7 @@ export default {
   components: { PopUp },
   methods: {
     validateForm () {
-      if (!this.exportName ) {
-        this.hasError = true
-      } else if (this.exportName) {
-        this.hasError = false
-      }
+      this.hasError = !this.exportName
     },
     exportMap () {
       if (!this.hasError && !this.exporting) {

--- a/tests/e2e/specs/long-running/layers/map-layers.js
+++ b/tests/e2e/specs/long-running/layers/map-layers.js
@@ -109,7 +109,7 @@ describe('Layer functionalities', () => {
             })
 
           cy.get(selector('close-button'))
-            .click({ force: true })
+            .should('not.exist')
         }
       })
     })

--- a/tests/e2e/specs/ui/export.js
+++ b/tests/e2e/specs/ui/export.js
@@ -54,6 +54,7 @@ describe('Maps export', () => {
     cy.readFile(path.join(downloadsFolder, `${fileName}.zip`))
       .should('exist')
 
-    cy.get(selector('close-button')).click()
+    cy.get(selector('close-button'))
+      .should('not.exist')
   })
 })


### PR DESCRIPTION
For the `ExportPopup.vue` see `/#/viewer/1` and click "Kaart exporteren". When no "naam" is given it should throw an error.

For the ExportCombinedPopUp.vue see `/#/combined/7/19435,19431/waterdepth` and click "Kaart exporteren". When no "schaal" is given it should throw an error.