### PR TITLE
Liwo 967 add scenario id in variant info

### DIFF
--- a/src/components/CombineChangeVariantPopup.vue
+++ b/src/components/CombineChangeVariantPopup.vue
@@ -135,7 +135,7 @@ export default {
     },
 
     getPropsForVariant (variant) {
-      return this.variantPropertiesToShow
+      const props = this.variantPropertiesToShow
         .filter(prop => variant.properties[prop] !== null && variant.properties[prop] !== undefined)
         .map(prop => {
           return {
@@ -143,6 +143,16 @@ export default {
             value: variant.properties[prop]
           }
         })
+
+      return [
+        ...(variant.properties?.["Scenario ID"]
+          ? [{
+              name: "Scenario ID",
+              value: variant.properties["Scenario ID"],
+            }]
+          : []),
+        ...props
+      ]
     },
 
     getWrappingTitle(variant) {

--- a/src/components/CombineLayerPanelItem.vue
+++ b/src/components/CombineLayerPanelItem.vue
@@ -145,6 +145,12 @@ export default {
           key: 'Variant',
           value: variant.metadata.title
         },
+        ...(variant.properties?.["Scenario ID"]
+          ? [{
+              key: "Scenario ID",
+              value: variant.properties["Scenario ID"],
+            }]
+          : []),
         ...props
       ]
     }


### PR DESCRIPTION
Go to `/#/scenarios/6/` and click on a scenario. In the metadata and when clicking on "Wijzig variant" the scenario id should be present